### PR TITLE
Link to DTS documentation added to project CEMS-2039

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Docs for Document Template System (DTS)
+
+## DTS RESTful API
+API documention to manage and render document templates.
+
+You can copy the contents of dts-documentation.yml and paste it into editor.swagger.io to view the rendered output.
+
+Link for Swagger documentation on Github.
+https://homeceu.github.io/dts-docs/#


### PR DESCRIPTION
Created a readme with a link to the swagger documentation, https://homeceu.github.io/dts-docs/#